### PR TITLE
Support AA Large and Fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,5 +78,17 @@ export function hex(a, b) {
  * score(10); // = 'AAA'
  */
 export function score(contrast) {
-  return contrast >= 7 ? "AAA" : contrast >= 4.5 ? "AA" : "";
+  if (contrast  >= 7) {
+    return 'AAA';
+  }
+  
+  if (contrast >= 4.5) {
+    return 'AA';
+  }
+  
+  if (contrast >= 3) {
+    return 'AA Large';
+  }
+  
+  return 'Fail';
 }


### PR DESCRIPTION
This adds `AA Large` from 3-4.5 and returns `'Fail'` when under 3 now. The empty string I think could be misconstrued as an error, since the output is not explicit.